### PR TITLE
Fix typo: IgnoreNodeManger -> IgnoreNodeManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Return true if `node` is wrapped any one of node `types`.
 - node `TxtNode` - is target node
 - types `Array.<string>` - are wrapped target node
 
-### class IgnoreNodeManger
+### class IgnoreNodeManager
 
 You can manager ignoring range in texts.
 
@@ -93,10 +93,10 @@ A rule for [textlint](https://github.com/textlint/textlint "textlint").
 
 ```js
 var RuleHelper = require("textlint-rule-helper").RuleHelper;
-var IgnoreNodeManger = require("textlint-rule-helper").IgnoreNodeManger;
+var IgnoreNodeManager = require("textlint-rule-helper").IgnoreNodeManager;
 module.exports = function (context) {
     var helper = new RuleHelper(context);
-    var ignoreNodeManager = new IgnoreNodeManger()
+    var ignoreNodeManager = new IgnoreNodeManager()
     var exports = {}
     var reportingErrors = [];
     exports[context.Syntax.Paragraph] = function(node){

--- a/src/IgnoreNodeManager.js
+++ b/src/IgnoreNodeManager.js
@@ -5,7 +5,7 @@ const visit = require('unist-util-visit');
  * Ignore node manager that manager ignored ranges.
  *
  */
-export default class IgnoreNodeManger {
+export default class IgnoreNodeManager {
     constructor() {
         /**
          * @type {[number,number][]}

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,8 @@
 // LICENSE : MIT
 "use strict";
 import RuleHelper from "./textlint-rule-helper";
-import IgnoreNodeManger from "./IgnoreNodeManger"
+import IgnoreNodeManager from "./IgnoreNodeManager"
 module.exports = {
-    IgnoreNodeManger,
+    IgnoreNodeManager,
     RuleHelper
 };

--- a/test/IgnoreNodeManager-test.js
+++ b/test/IgnoreNodeManager-test.js
@@ -1,9 +1,9 @@
 // LICENSE : MIT
 "use strict";
 import assert from 'power-assert'
-import IgnoreNodeManger from "../src/IgnoreNodeManger";
+import IgnoreNodeManager from "../src/IgnoreNodeManager";
 import {textlint} from "textlint"
-describe("IgnoreNodeManger", function () {
+describe("IgnoreNodeManager", function () {
     afterEach(function () {
         textlint.resetRules();
     });
@@ -12,7 +12,7 @@ describe("IgnoreNodeManger", function () {
             it("should ignore range by index", () => {
                 var text = "text`code`text";
                 var isIgnored = false;
-                const ignoreManager = new IgnoreNodeManger();
+                const ignoreManager = new IgnoreNodeManager();
                 textlint.setupRules({
                     "rule-key": function (context) {
                         const {Syntax, RuleError, report, getSource} = context;


### PR DESCRIPTION
This PR fixes a tiny typo, but introduces a breaking change.
I know in general we should avoid breaking changes as much as possible.
However I believe it's worthwhile to bump the major version this time for the following reasons:

- Misspelling in a name of exposed APIs is very confusing to API users (like me).
- It hasn't been a long time since IgnoreNodeMan(a)ger was added, so the impact of this change is not so big for now.

What do you think?