### PR TITLE
chore(test): remove allowJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "build": "cross-env NODE_ENV=production tsc -p .",
     "prepublish": "npm run --if-present build",
-    "test": "mocha \"test/**/*.{js,ts}\"",
+    "test": "mocha \"test/**/*.ts\"",
     "watch": "tsc -p . --watch"
   },
   "dependencies": {

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "declaration": false,
         "noEmit": true,
-        "allowJs": true
     },
     "include": [
         "../src/**/*",


### PR DESCRIPTION
I have read [Babelで書かれたJavaScriptライブラリをTypeScriptへ移行する方法 | Web Scratch](https://efcl.info/2019/01/09/babel-to-typescript-library/#5-%E3%83%86%E3%82%B9%E3%83%88%E3%82%B3%E3%83%BC%E3%83%89%E3%82%92-test-%E3%82%92typescript%E3%81%B8%E5%A4%89%E6%8F%9B%E3%81%99%E3%82%8B).

the article recommends to remove `allowJs` from `test/tsconfig.json`.
In this repository, however, allowJS is still present.
Thus, I remove it.